### PR TITLE
Redirect to login when cdsso is enabled and bypass issuer match with …

### DIFF
--- a/src/policyagent/policy-agent.ts
+++ b/src/policyagent/policy-agent.ts
@@ -363,9 +363,11 @@ export class PolicyAgent extends EventEmitter {
     const notOnOrAfter = new Date(conditions.$.NotOnOrAfter);
 
     // check Issuer
-    if (assertion.$.Issuer !== this.options.serverUrl + '/cdcservlet') {
-      throw new Error('Unknown issuer: ' + assertion.$.Issuer);
-    }
+    // OpenAm is returning hostname instead of domain name which we can't change
+    // so we can't match issuer.
+    // if (assertion.$.Issuer !== this.options.serverUrl + '/cdcservlet') {
+    //   throw new Error('Unknown issuer: ' + assertion.$.Issuer);
+    // }
 
     // check AuthnResponse dates
     if (now < notBefore || now >= notOnOrAfter) {

--- a/src/shield/cookie-shield.ts
+++ b/src/shield/cookie-shield.ts
@@ -105,16 +105,17 @@ export class CookieShield implements Shield {
       throw new ShieldEvaluationError(401, 'Unauthorized', 'Invalid session');
     }
 
+    // cdsso: return false so can be redirected to login page.
+    if (this.options.cdsso) {
+      return false;
+    }
+
     if (!(await this.checkDomainMatch(req, agent))) {
       throw new ShieldEvaluationError(400, 'Bad Request', 'Domain mismatch');
     }
   }
 
   private async checkDomainMatch(req: IncomingMessage, agent: PolicyAgent): Promise<boolean> {
-    if (this.options.cdsso) {
-      return false;
-    }
-
     let domainMatch = false;
     const { domains } = await agent.getServerInfo();
 


### PR DESCRIPTION
…server

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ForgeRock/node-openam-agent/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] A PR for the wiki has been submitted to https://github.com/ForgeRock/node-openam-agent.wiki.git as needed (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


## What is the current behavior?
When CDSSO is enabled, it gives `Bad Request 400` Error from `checkDomainMatch` function in cookie shield.

Issue Number: N/A


## What is the new behavior?
When CDSSO is enabled, it will go through the login.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
