### PR TITLE
Add missing package from dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@types/basic-auth": "^1.1.2",
     "@types/express": "^4.16.0",
+    "@types/express-serve-static-core": "^4.17.0",
     "@types/handlebars": "^4.0.39",
     "@types/jest": "^23.3.9",
     "@types/node": "^10.12.2",


### PR DESCRIPTION
* Add missing package.json dev-dependency for `express-serve-static-core` types.